### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Margays/charts/security/code-scanning/1](https://github.com/Margays/charts/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required for the `GITHUB_TOKEN`. Since the workflow primarily involves reading repository contents and interacting with pull requests, the permissions can be set to `contents: read` and `pull-requests: write`. This ensures that the workflow has only the necessary permissions to perform its tasks.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. If specific jobs require different permissions, additional `permissions` blocks can be added at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
